### PR TITLE
Don't obfuscate email addresses

### DIFF
--- a/site.cabal
+++ b/site.cabal
@@ -19,6 +19,7 @@ Executable site
   Main-Is:              site.hs
   Build-Depends:        base
                       , hakyll == 4.7.*
+                      , pandoc
                       , site
 
 Source-Repository head

--- a/site.hs
+++ b/site.hs
@@ -2,6 +2,10 @@
 
 import Hakyll hiding (pandocCompiler)
 import Text.Pandoc
+    ( writerEmailObfuscation
+    , ObfuscationMethod( NoObfuscation )
+    )
+
 import IndexedRoute
 
 main :: IO ()

--- a/site.hs
+++ b/site.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Hakyll
+import Hakyll hiding (pandocCompiler)
+import Text.Pandoc
 import IndexedRoute
 
 main :: IO ()
@@ -61,6 +62,11 @@ main = hakyll $ do
     match "root/*" $ do
         route $ gsubRoute "root/" (const "")
         compile copyFileCompiler
+
+pandocCompiler :: Compiler (Item String)
+pandocCompiler = pandocCompilerWith
+    defaultHakyllReaderOptions
+    defaultHakyllWriterOptions { writerEmailObfuscation = NoObfuscation }
 
 siteTitle :: String
 siteTitle = "Gordon Fontenot"


### PR DESCRIPTION
This really doesn't matter too much, and leaving the obfuscation in
means that we get warnings in RSS feeds if we're using a mail link. I
think it makes the most sense to turn this off.

Learned in this PR:
- `hiding`. Very cool.
- That syntax for creating a new instance of something with a changed
  value. I have no idea what that is or why it works and that scares me
  a little but hey, here we are.
