### PR TITLE
Check links as part of CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,13 @@
 machine:
   ghc:
     version: 7.10.1
+
+test:
+  override:
+    - cabal build
+    - cabal run -- build
+    - cabal run -- check
+
 deployment:
   master:
     branch: master

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
   override:
     - cabal build
     - cabal run -- build
-    - cabal run -- check
+    - cabal run -- check --internal-links
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,9 @@ machine:
 test:
   override:
     - cabal build
-    - cabal run -- build
-    - cabal run -- check --internal-links
+    - ./site clean
+    - ./site build
+    - ./site check --internal-links
 
 deployment:
   master:

--- a/partials/head.html
+++ b/partials/head.html
@@ -6,7 +6,7 @@
 <meta name="designer" content="Gordon Fontenot" />
 <meta name="viewport" content="width=device-width" />
 
-<script src="javascript/analytics.js"></script>
+<script src="/javascript/analytics.js"></script>
 
 <link href="/css/reset.css" rel="stylesheet" media="all" />
 <link href="/css/fontello.css" rel="stylesheet" media="all" />


### PR DESCRIPTION
Turns out, the executable built with `Hakyll` has a nifty `check` command that
checks all links in your website and confirms that they actually link to
something. This seems _super_ useful. Lets use this functionality as our CI
test.

Unfortunately, checking _external_ links can break, as is the case for all
links to developer.apple.com. I'd love to figure out _why_ those are breaking
(I get a 401 from them), but for now, we can just check internal links only.
