### PR TITLE
[WIP] Add year archives

### DIFF
--- a/site.cabal
+++ b/site.cabal
@@ -16,6 +16,7 @@ Executable site
                       , hakyll == 4.7.*
                       , pandoc
                       , filepath
+                      , containers
 
 Source-Repository head
   Type:                 git

--- a/src/Site.hs
+++ b/src/Site.hs
@@ -9,10 +9,12 @@ import Site.Contexts
 import Site.Configurations
 import Site.URLHelper
 import Site.Compilers
+import Site.Years
 
 main :: IO ()
 main = hakyllWith hakyllConfig $ do
     tags <- buildTags allPosts $ fromCapture "blog/tags/*/index.html"
+    years <- buildYears allPosts $ fromCapture "blog/archive/*/index.html"
 
     match allPosts $ do
         route indexedPostRoute
@@ -29,6 +31,17 @@ main = hakyllWith hakyllConfig $ do
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/tag.html" ctx
+                >>= loadAndApplyTemplate "templates/default.html" ctx
+                >>= replaceIndexLinks
+
+    yearsRules years $ \year pattern -> do
+        route idRoute
+        compile $ do
+            posts <- recentFirst =<< loadAllSnapshots pattern "content"
+            let ctx = blogCtx posts tags year
+
+            makeItem ""
+                >>= loadAndApplyTemplate "templates/blog.html" ctx
                 >>= loadAndApplyTemplate "templates/default.html" ctx
                 >>= replaceIndexLinks
 

--- a/src/Site.hs
+++ b/src/Site.hs
@@ -25,12 +25,7 @@ main = hakyllWith hakyllConfig $ do
         route idRoute
         compile $ do
             posts <- recentFirst =<< loadAllSnapshots pattern "content"
-
-            let ctx = mconcat
-                    [ listField "posts" (postCtx tags) (return posts)
-                    , constField "title" tag
-                    , defaultContext
-                    ]
+            let ctx = blogCtx posts tags tag
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/tag.html" ctx
@@ -40,8 +35,8 @@ main = hakyllWith hakyllConfig $ do
     create ["index.html"] $ do
         route idRoute
         compile $ do
-            posts <- recentFirst =<< loadAll allPosts
-            let ctx = blogCtx posts tags
+            posts <- recentFirst =<< loadAllSnapshots allPosts "content"
+            let ctx = blogCtx posts tags siteTitle
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/blog.html" ctx

--- a/src/Site/Contexts.hs
+++ b/src/Site/Contexts.hs
@@ -6,12 +6,10 @@ module Site.Contexts
 
 import Hakyll
 
-import Site.Constants
-
-blogCtx :: [Item String] -> Tags -> Context String
-blogCtx posts tags = mconcat
+blogCtx :: [Item String] -> Tags -> String -> Context String
+blogCtx posts tags title = mconcat
     [ listField "posts" (postCtx tags) (return posts)
-    , constField "title" siteTitle
+    , constField "title" title
     , defaultContext
     ]
 

--- a/src/Site/Years.hs
+++ b/src/Site/Years.hs
@@ -1,0 +1,41 @@
+module Site.Years
+    ( Years(..)
+    , yearsRules
+    , buildYears
+    , getYear
+    ) where
+
+import Hakyll
+import System.FilePath (takeBaseName)
+import Control.Monad (foldM, forM_)
+import qualified Data.Set as S
+import qualified Data.Map as M
+
+data Years = Years
+    { yearsMap        :: [(String, [Identifier])]
+    , yearsMakeId     :: String -> Identifier
+    , yearsDependency :: Dependency
+    } deriving (Show)
+
+yearsRules :: Years -> (String -> Pattern -> Rules ()) -> Rules ()
+yearsRules years rules =
+    forM_ (yearsMap years) $ \(year, identifiers) ->
+        rulesExtraDependencies [yearsDependency years] $
+            create [yearsMakeId years year] $
+                rules year $ fromList identifiers
+
+buildYears :: MonadMetadata m => Pattern -> (String -> Identifier) -> m Years
+buildYears pattern makeId = do
+    ids <- getMatches pattern
+    yearMap <- foldM addYear M.empty ids
+    let set' = S.fromList ids
+    return $ Years (M.toList yearMap) makeId (PatternDependency pattern set')
+
+  where
+    addYear yearMap id' = do
+        let year = getYear id'
+        let yearMap' = M.singleton year [id']
+        return $ M.unionWith (++) yearMap yearMap'
+
+getYear :: Identifier -> String
+getYear = take 4 . takeBaseName . toFilePath


### PR DESCRIPTION
This generates yearly archives at `blog/archive/YYYY`. It's based heavily on the
Tags implementation provided by Hakyll. As in it's basically stolen wholesale.
But it's a really nice API.

TODO:
- [ ] Build a page at `blog/archive/` that lists the years (and maybe the
  posts in those years?
- [ ] Add a link to the archive to the main page somewhere
- [ ] Refactor like crazy
