### PR TITLE
Show drafts when running a preview server

### DIFF
--- a/site.cabal
+++ b/site.cabal
@@ -16,6 +16,7 @@ Executable site
                       , Site.Configurations
                       , Site.Constants
                       , Site.Contexts
+                      , Site.Fields
                       , Site.Patterns
                       , Site.Routes
                       , Site.URLHelper
@@ -23,6 +24,8 @@ Executable site
                       , hakyll
                       , pandoc
                       , filepath
+                      , time
+                      , time-locale-compat
 
 Source-Repository head
   Type:                 git

--- a/src/Site.hs
+++ b/src/Site.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Hakyll
+import System.Environment (getArgs)
 
 import Site.Constants
 import Site.Routes
@@ -11,101 +12,112 @@ import Site.URLHelper
 import Site.Compilers
 
 main :: IO ()
-main = hakyllWith hakyllConfig $ do
-    tags <- buildTags allPosts $ fromCapture "blog/tags/*/index.html"
+main = do
+    (action:_) <- getArgs
 
-    match (allPosts .||. drafts) $ do
-        route indexedPostRoute
-        compile $ baseCompiler
-            >>= saveSnapshot "content"
-            >>= loadAndApplyTemplate "templates/post.html" (postCtx tags)
-            >>= replaceIndexLinks
+    let showDrafts = action == "watch"
 
-    tagsRules tags $ \tag pattern -> do
-        route idRoute
-        compile $ do
-            posts <- recentFirst =<< loadAllSnapshots pattern "content"
+    hakyllWith hakyllConfig $ do
+        tags <- buildTags allPosts $ fromCapture "blog/tags/*/index.html"
 
-            let ctx = mconcat
-                    [ listField "posts" (postCtx tags) (return posts)
-                    , constField "title" tag
-                    , defaultContext
-                    ]
+        let postsPattern = case showDrafts of
+                True -> allPosts .||. drafts
+                False -> allPosts
 
-            makeItem ""
-                >>= loadAndApplyTemplate "templates/tag.html" ctx
-                >>= loadAndApplyTemplate "templates/default.html" ctx
+        match postsPattern $ do
+            route indexedPostRoute
+            compile $ baseCompiler
+                >>= saveSnapshot "content"
+                >>= loadAndApplyTemplate "templates/post.html" (postCtx showDrafts tags)
                 >>= replaceIndexLinks
 
-    create ["index.html"] $ do
-        route idRoute
-        compile $ do
-            publishedPosts <- recentFirst =<< loadAll allPosts
-            draftPosts <- loadAll drafts
+        tagsRules tags $ \tag pattern -> do
+            route idRoute
+            compile $ do
+                posts <- recentFirst =<< loadAllSnapshots pattern "content"
 
-            let posts = draftPosts ++ publishedPosts
+                let ctx = mconcat
+                        [ listField "posts" (postCtx showDrafts tags) (return posts)
+                        , constField "title" tag
+                        , defaultContext
+                        ]
 
-            let ctx = blogCtx posts tags
+                makeItem ""
+                    >>= loadAndApplyTemplate "templates/tag.html" ctx
+                    >>= loadAndApplyTemplate "templates/default.html" ctx
+                    >>= replaceIndexLinks
 
-            makeItem ""
-                >>= loadAndApplyTemplate "templates/blog.html" ctx
-                >>= loadAndApplyTemplate "templates/default.html" ctx
+        create ["index.html"] $ do
+            route idRoute
+            compile $ do
+                publishedPosts <- recentFirst =<< loadAll allPosts
+                draftPosts <- loadAll drafts
+
+                let posts = case showDrafts of
+                        True -> draftPosts ++ publishedPosts
+                        False -> publishedPosts
+
+                let ctx = blogCtx showDrafts posts tags
+
+                makeItem ""
+                    >>= loadAndApplyTemplate "templates/blog.html" ctx
+                    >>= loadAndApplyTemplate "templates/default.html" ctx
+                    >>= replaceIndexLinks
+
+        create ["feed.xml"] $ do
+            route idRoute
+            compile $ do
+                posts <- recentFirst =<< loadAllSnapshots allPosts "content"
+
+                renderAtom feedConfig feedItemCtx posts
+                    >>= replaceIndexURLs siteHost
+                    >>= repairExternalURLs siteHost
+                    >>= replaceRelativeURLs siteHost
+
+        match "pages/*" $ do
+            route makeIndexed
+            compile $ baseCompiler
+                >>= loadAndApplyTemplate "templates/page.html" defaultContext
                 >>= replaceIndexLinks
 
-    create ["feed.xml"] $ do
-        route idRoute
-        compile $ do
-            posts <- recentFirst =<< loadAllSnapshots allPosts "content"
+        match "resume.html" $ do
+            route makeIndexed
+            compile copyFileCompiler
 
-            renderAtom feedConfig feedItemCtx posts
-                >>= replaceIndexURLs siteHost
-                >>= repairExternalURLs siteHost
-                >>= replaceRelativeURLs siteHost
+        match "404.markdown" $ do
+            route toHTML
+            compile $ baseCompiler
+                >>= loadAndApplyTemplate "templates/default.html" defaultContext
+                >>= replaceIndexLinks
 
-    match "pages/*" $ do
-        route makeIndexed
-        compile $ baseCompiler
-            >>= loadAndApplyTemplate "templates/page.html" defaultContext
-            >>= replaceIndexLinks
+        match "pgp/keybase.txt" $ do
+            route wellKnown
+            compile copyFileCompiler
 
-    match "resume.html" $ do
-        route makeIndexed
-        compile copyFileCompiler
+        match "root/nojekyll" $ do
+            route makeHidden
+            compile copyFileCompiler
 
-    match "404.markdown" $ do
-        route toHTML
-        compile $ baseCompiler
-            >>= loadAndApplyTemplate "templates/default.html" defaultContext
-            >>= replaceIndexLinks
+        scssDependencies <- makePatternDependency "scss/*.scss"
+        rulesExtraDependencies [scssDependencies] $ do
+            match "scss/screen.scss" $ do
+                route cssRoute
+                compile sassCompiler
 
-    match "pgp/keybase.txt" $ do
-        route wellKnown
-        compile copyFileCompiler
-
-    match "root/nojekyll" $ do
-        route makeHidden
-        compile copyFileCompiler
-
-    scssDependencies <- makePatternDependency "scss/*.scss"
-    rulesExtraDependencies [scssDependencies] $ do
-        match "scss/screen.scss" $ do
+        match "css/*" $ do
             route cssRoute
-            compile sassCompiler
+            compile compressCssCompiler
 
-    match "css/*" $ do
-        route cssRoute
-        compile compressCssCompiler
+        compileTemplates $
+                 "templates/*"
+            .||. "partials/*"
 
-    compileTemplates $
-             "templates/*"
-        .||. "partials/*"
+        copyInPlace $
+                 "images/**"
+            .||. "javascript/*"
+            .||. "font/*"
+            .||. "pgp/*"
 
-    copyInPlace $
-             "images/**"
-        .||. "javascript/*"
-        .||. "font/*"
-        .||. "pgp/*"
-
-    match "root/*" $ do
-        route makeRoot
-        compile copyFileCompiler
+        match "root/*" $ do
+            route makeRoot
+            compile copyFileCompiler

--- a/src/Site.hs
+++ b/src/Site.hs
@@ -14,11 +14,11 @@ main :: IO ()
 main = hakyllWith hakyllConfig $ do
     tags <- buildTags allPosts $ fromCapture "blog/tags/*/index.html"
 
-    match allPosts $ do
+    match (allPosts .||. drafts) $ do
         route indexedPostRoute
         compile $ baseCompiler
             >>= saveSnapshot "content"
-            >>= loadAndApplyTemplate "templates/post.html"    (postCtx tags)
+            >>= loadAndApplyTemplate "templates/post.html" (postCtx tags)
             >>= replaceIndexLinks
 
     tagsRules tags $ \tag pattern -> do
@@ -40,7 +40,11 @@ main = hakyllWith hakyllConfig $ do
     create ["index.html"] $ do
         route idRoute
         compile $ do
-            posts <- recentFirst =<< loadAll allPosts
+            publishedPosts <- recentFirst =<< loadAll allPosts
+            draftPosts <- loadAll drafts
+
+            let posts = draftPosts ++ publishedPosts
+
             let ctx = blogCtx posts tags
 
             makeItem ""

--- a/src/Site/Contexts.hs
+++ b/src/Site/Contexts.hs
@@ -7,6 +7,7 @@ module Site.Contexts
 import Hakyll
 
 import Site.Constants
+import Site.Fields
 
 blogCtx :: [Item String] -> Tags -> Context String
 blogCtx posts tags = mconcat
@@ -17,7 +18,8 @@ blogCtx posts tags = mconcat
 
 postCtx :: Tags -> Context String
 postCtx tags = mconcat
-    [ dateField "date" "%b %d, %Y"
+    [ todayField "date" "%b %d, %Y"
+    , dateField "date" "%b %d, %Y"
     , tagsField "tags" tags
     , defaultContext
     ]

--- a/src/Site/Contexts.hs
+++ b/src/Site/Contexts.hs
@@ -9,17 +9,26 @@ import Hakyll
 import Site.Constants
 import Site.Fields
 
-blogCtx :: [Item String] -> Tags -> Context String
-blogCtx posts tags = mconcat
-    [ listField "posts" (postCtx tags) (return posts)
+blogCtx :: Bool -> [Item String] -> Tags -> Context String
+blogCtx showDrafts posts tags = mconcat
+    [ listField "posts" (postCtx showDrafts tags) (return posts)
     , constField "title" siteTitle
     , defaultContext
     ]
 
-postCtx :: Tags -> Context String
-postCtx tags = mconcat
+postCtx :: Bool -> Tags -> Context String
+postCtx showDrafts tags = mconcat $
+    draftFields showDrafts ++ postFields tags
+
+draftFields :: Bool -> [Context String]
+draftFields False = []
+draftFields True =
     [ todayField "date" "%b %d, %Y"
-    , dateField "date" "%b %d, %Y"
+    ]
+
+postFields :: Tags -> [Context String]
+postFields tags =
+    [ dateField "date" "%b %d, %Y"
     , draftField "isDraft"
     , tagsField "tags" tags
     , defaultContext

--- a/src/Site/Contexts.hs
+++ b/src/Site/Contexts.hs
@@ -20,6 +20,7 @@ postCtx :: Tags -> Context String
 postCtx tags = mconcat
     [ todayField "date" "%b %d, %Y"
     , dateField "date" "%b %d, %Y"
+    , draftField "isDraft"
     , tagsField "tags" tags
     , defaultContext
     ]

--- a/src/Site/Fields.hs
+++ b/src/Site/Fields.hs
@@ -1,16 +1,25 @@
 module Site.Fields
-    ( todayField
+    ( draftField
+    , todayField
     ) where
 
 import Hakyll
     ( Context
+    , Item(..)
+    , boolField
     , field
     , unsafeCompiler
+    , matches
     )
+
+import Site.Patterns
 
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Format (formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
+
+draftField :: String -> Context a
+draftField key = boolField key $ matches drafts . itemIdentifier
 
 todayField :: String -> String -> Context a
 todayField key format = field key $ \_ -> do

--- a/src/Site/Fields.hs
+++ b/src/Site/Fields.hs
@@ -1,0 +1,19 @@
+module Site.Fields
+    ( todayField
+    ) where
+
+import Hakyll
+    ( Context
+    , field
+    , unsafeCompiler
+    )
+
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Format (formatTime)
+import Data.Time.Locale.Compat (defaultTimeLocale)
+
+todayField :: String -> String -> Context a
+todayField key format = field key $ \_ -> do
+    let locale = defaultTimeLocale
+    now <- unsafeCompiler getCurrentTime
+    return $ formatTime locale format now

--- a/src/Site/Patterns.hs
+++ b/src/Site/Patterns.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Site.Patterns (allPosts) where
+module Site.Patterns
+    ( allPosts
+    , drafts
+    ) where
 
 import Hakyll (Pattern, (.||.))
 
 allPosts :: Pattern
 allPosts = "posts/*" .||. "stubs/*"
+
+drafts :: Pattern
+drafts = "drafts/*"

--- a/web/scss/blog.scss
+++ b/web/scss/blog.scss
@@ -19,6 +19,10 @@ article {
   padding-bottom: 0.5em;
 }
 
+#blog a.draft {
+  color: $main-color;
+}
+
 #blog li.external:after {
   content: "";
   display: inline-block;

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -2,7 +2,7 @@
   $for(posts)$
     <li $if(external)$ class="external" $endif$>
       <h3>
-        <a href="$url$">$title$</a>
+        <a href="$url$" $if(isDraft)$ class="draft" $endif$>$title$</a>
       </h3>
     </li>
   $endfor$


### PR DESCRIPTION
If we're running a preview server via `site watch`, it'd be nice to see all of
our drafts as well. These are stored in `web/drafts` (ignored by git), and
don't include any date info. To accommodate this, we need to add some
functionality like flagging drafts and adding a default date to posts that
don't have one.

I _highly_ recommend viewing this PR using the hidden `?w=1` flag that hides
whitespace changes.